### PR TITLE
[TASK] Add note for not supported multiline values in constants (7.6)

### DIFF
--- a/Documentation/TypoScriptTemplates/Constants/Index.rst
+++ b/Documentation/TypoScriptTemplates/Constants/Index.rst
@@ -30,6 +30,11 @@ which are later used in *several places*.
    The top-level "object" :code:`TSConstantEditor` cannot be used. It is
    reserved for the :ref:`configuration of help in the Constant Editor module <constant-editor-categories>`.
 
+.. important::
+
+   **Multi-line values: The ( ) signs**
+
+   Constants do not support multiline values!
 
 Example
 ~~~~~~~


### PR DESCRIPTION
See https://forge.typo3.org/issues/17379#note-9